### PR TITLE
feat: Hardened storage engines

### DIFF
--- a/src/main/engine/FileEngine.ts
+++ b/src/main/engine/FileEngine.ts
@@ -60,7 +60,7 @@ export default class FileEngine implements CRUDEngine {
                 resolve(primaryKey);
               }
             });
-          });
+          }).catch(reject);
       } else {
         const message: string = `Record "${primaryKey}" cannot be saved in "${tableName}" because it's "undefined" or "null".`;
         reject(new RecordTypeError(message));
@@ -150,7 +150,8 @@ export default class FileEngine implements CRUDEngine {
             const updatedRecord: Object = {...record, ...changes};
             return JSON.stringify(updatedRecord);
           })
-          .then((updatedRecord: any) => this.create(tableName, primaryKey, updatedRecord));
+          .then((updatedRecord: any) => fs.outputFile(file, updatedRecord))
+          .then(() => primaryKey);
       });
   }
 }

--- a/src/main/engine/FileEngine.ts
+++ b/src/main/engine/FileEngine.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
 import CRUDEngine from './CRUDEngine';
 import path = require('path');
-import {PathValidationError} from './error';
+import {PathValidationError, RecordNotFoundError} from './error';
 
 export default class FileEngine implements CRUDEngine {
   constructor(public storeName: string, private options: {fileExtension: string} = {
@@ -62,7 +62,8 @@ export default class FileEngine implements CRUDEngine {
         fs.readFile(file, {encoding: 'utf8', flag: 'r'}, (error: any, data: any) => {
           if (error) {
             if (error.code === 'ENOENT') {
-              resolve(undefined);
+              const message: string = `Record "${primaryKey}" in "${tableName}" could not be found.`;
+              reject(new RecordNotFoundError(message));
             } else {
               reject(error);
             }

--- a/src/main/engine/FileEngine.ts
+++ b/src/main/engine/FileEngine.ts
@@ -44,12 +44,12 @@ export default class FileEngine implements CRUDEngine {
               }
             }
 
-            fs.writeFile(file, entity, {flag: 'wx'}, (error) => {
+            fs.writeFile(file, entity, {flag: 'wx'}, error => {
               if (error) {
                 if (error.code === 'ENOENT') {
                   fs.outputFile(file, entity)
                     .then(() => resolve(primaryKey))
-                    .catch((error) => reject(error));
+                    .catch(error => reject(error));
                 } else if (error.code === 'EEXIST') {
                   const message: string = `Record "${primaryKey}" already exists in "${tableName}". You need to delete the record first if you want to overwrite it.`;
                   reject(new RecordAlreadyExistsError(message));
@@ -60,7 +60,8 @@ export default class FileEngine implements CRUDEngine {
                 resolve(primaryKey);
               }
             });
-          }).catch(reject);
+          })
+          .catch(reject);
       } else {
         const message: string = `Record "${primaryKey}" cannot be saved in "${tableName}" because it's "undefined" or "null".`;
         reject(new RecordTypeError(message));
@@ -95,6 +96,7 @@ export default class FileEngine implements CRUDEngine {
             try {
               data = JSON.parse(data);
             } catch (error) {
+              // No JSON found but that's okay
             }
             resolve(data);
           }

--- a/src/main/engine/IndexedDBEngine.ts
+++ b/src/main/engine/IndexedDBEngine.ts
@@ -22,7 +22,7 @@ export default class IndexedDBEngine implements CRUDEngine {
         });
     }
     const message: string = `Record "${primaryKey}" cannot be saved in "${tableName}" because it's "undefined" or "null".`;
-    throw new RecordTypeError(message);
+    return Promise.reject(new RecordTypeError(message));
   }
 
   public delete(tableName: string, primaryKey: string): Promise<string> {

--- a/src/main/engine/IndexedDBEngine.ts
+++ b/src/main/engine/IndexedDBEngine.ts
@@ -13,7 +13,7 @@ export default class IndexedDBEngine implements CRUDEngine {
     if (entity) {
       return this.db[tableName].add(entity, primaryKey)
         .catch((error) => {
-          if (error.name === 'ConstraintError') {
+          if (error instanceof Dexie.ConstraintError) {
             const message: string = `Record "${primaryKey}" already exists in "${tableName}". You need to delete the record first if you want to overwrite it.`;
             throw new RecordAlreadyExistsError(message);
           } else {

--- a/src/main/engine/IndexedDBEngine.ts
+++ b/src/main/engine/IndexedDBEngine.ts
@@ -1,5 +1,6 @@
 import CRUDEngine from './CRUDEngine';
 import Dexie from 'dexie';
+import {RecordNotFoundError} from './error';
 
 export default class IndexedDBEngine implements CRUDEngine {
   public storeName: string;
@@ -30,7 +31,15 @@ export default class IndexedDBEngine implements CRUDEngine {
   }
 
   public read<T>(tableName: string, primaryKey: string): Promise<T> {
-    return this.db[tableName].get(primaryKey);
+    return Promise.resolve().then(() => {
+      return this.db[tableName].get(primaryKey);
+    }).then((record: T) => {
+      if (record) {
+        return record;
+      }
+      const message: string = `Record "${primaryKey}" from store "${tableName}" could not be found.`;
+      throw new RecordNotFoundError(message);
+    });
   }
 
   public readAll<T>(tableName: string): Promise<T[]> {

--- a/src/main/engine/LocalStorageEngine.ts
+++ b/src/main/engine/LocalStorageEngine.ts
@@ -14,7 +14,7 @@ export default class LocalStorageEngine implements CRUDEngine {
           return this.read(tableName, primaryKey);
         })
         .catch((error) => {
-          if (error.name === 'RecordNotFoundError') {
+          if (error instanceof RecordNotFoundError) {
             return undefined
           }
           throw error;
@@ -98,7 +98,7 @@ export default class LocalStorageEngine implements CRUDEngine {
     }).then((updatedEntity: Object) => {
       return this.create(tableName, primaryKey, updatedEntity)
         .catch((error) => {
-          if (error.name === 'RecordAlreadyExistsError') {
+          if (error instanceof RecordAlreadyExistsError) {
             return this.delete(tableName, primaryKey).then(() => this.create(tableName, primaryKey, updatedEntity));
           } else {
             throw error;

--- a/src/main/engine/LocalStorageEngine.ts
+++ b/src/main/engine/LocalStorageEngine.ts
@@ -10,12 +10,10 @@ export default class LocalStorageEngine implements CRUDEngine {
     if (entity) {
       const key: string = `${this.storeName}@${tableName}@${primaryKey}`;
       return Promise.resolve()
-        .then(() => {
-          return this.read(tableName, primaryKey);
-        })
+        .then(() => this.read(tableName, primaryKey))
         .catch((error) => {
           if (error instanceof RecordNotFoundError) {
-            return undefined
+            return undefined;
           }
           throw error;
         })
@@ -54,15 +52,16 @@ export default class LocalStorageEngine implements CRUDEngine {
   }
 
   public read<T>(tableName: string, primaryKey: string): Promise<T> {
-    return Promise.resolve().then(() => {
-      const key: string = `${this.storeName}@${tableName}@${primaryKey}`;
-      const record = window.localStorage.getItem(key);
-      if (record) {
-        return JSON.parse(record);
-      }
-      const message: string = `Record "${primaryKey}" in "${tableName}" could not be found.`;
-      throw new RecordNotFoundError(message);
-    });
+    return Promise.resolve()
+      .then(() => {
+        const key: string = `${this.storeName}@${tableName}@${primaryKey}`;
+        const record = window.localStorage.getItem(key);
+        if (record) {
+          return JSON.parse(record);
+        }
+        const message: string = `Record "${primaryKey}" in "${tableName}" could not be found.`;
+        throw new RecordNotFoundError(message);
+      });
   }
 
   public readAll<T>(tableName: string): Promise<T[]> {

--- a/src/main/engine/LocalStorageEngine.ts
+++ b/src/main/engine/LocalStorageEngine.ts
@@ -11,7 +11,7 @@ export default class LocalStorageEngine implements CRUDEngine {
       const key: string = `${this.storeName}@${tableName}@${primaryKey}`;
       return Promise.resolve()
         .then(() => this.read(tableName, primaryKey))
-        .catch((error) => {
+        .catch(error => {
           if (error instanceof RecordNotFoundError) {
             return undefined;
           }

--- a/src/main/engine/LocalStorageEngine.ts
+++ b/src/main/engine/LocalStorageEngine.ts
@@ -13,6 +13,12 @@ export default class LocalStorageEngine implements CRUDEngine {
         .then(() => {
           return this.read(tableName, primaryKey);
         })
+        .catch((error) => {
+          if (error.name === 'RecordNotFoundError') {
+            return undefined
+          }
+          throw error;
+        })
         .then((record: T) => {
           if (record) {
             const message: string = `Record "${primaryKey}" already exists in "${tableName}". You need to delete the record first if you want to overwrite it.`;
@@ -50,7 +56,12 @@ export default class LocalStorageEngine implements CRUDEngine {
   public read<T>(tableName: string, primaryKey: string): Promise<T> {
     return Promise.resolve().then(() => {
       const key: string = `${this.storeName}@${tableName}@${primaryKey}`;
-      return JSON.parse(window.localStorage.getItem(key)) || undefined;
+      const record = window.localStorage.getItem(key);
+      if (record) {
+        return JSON.parse(record);
+      }
+      const message: string = `Record "${primaryKey}" in "${tableName}" could not be found.`;
+      throw new RecordNotFoundError(message);
     });
   }
 

--- a/src/main/engine/LocalStorageEngine.ts
+++ b/src/main/engine/LocalStorageEngine.ts
@@ -96,7 +96,7 @@ export default class LocalStorageEngine implements CRUDEngine {
       return Object.assign(entity, changes);
     }).then((updatedEntity: Object) => {
       return this.create(tableName, primaryKey, updatedEntity)
-        .catch((error) => {
+        .catch(error => {
           if (error instanceof RecordAlreadyExistsError) {
             return this.delete(tableName, primaryKey).then(() => this.create(tableName, primaryKey, updatedEntity));
           } else {

--- a/src/main/engine/error/RecordNotFoundError.ts
+++ b/src/main/engine/error/RecordNotFoundError.ts
@@ -1,7 +1,7 @@
-export default class RecordAlreadyExistsError extends Error {
+export default class RecordNotFoundError extends Error {
   constructor(public message: string) {
     super(message);
-    Object.setPrototypeOf(this, RecordAlreadyExistsError.prototype);
+    Object.setPrototypeOf(this, RecordNotFoundError.prototype);
 
     this.message = message;
     this.name = (<any>this).constructor.name;

--- a/src/main/engine/error/index.ts
+++ b/src/main/engine/error/index.ts
@@ -1,9 +1,11 @@
 import PathValidationError from './PathValidationError';
 import RecordAlreadyExistsError from './RecordAlreadyExistsError';
+import RecordNotFoundError from './RecordNotFoundError';
 import RecordTypeError from './RecordTypeError';
 
 export {
   PathValidationError,
   RecordAlreadyExistsError,
+  RecordNotFoundError,
   RecordTypeError,
 };

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
-import {ExpiredBundle, RecordAlreadyExistsError, TransientBundle, TransientStore} from './store';
+import {ExpiredBundle, TransientBundle, TransientStore} from './store';
 import {FileEngine, IndexedDBEngine, MemoryEngine, LocalStorageEngine} from './engine';
-import {PathValidationError} from './engine/error';
+import {PathValidationError, RecordAlreadyExistsError, RecordNotFoundError, RecordTypeError} from './engine/error';
 
 export = {
   Store: {
@@ -12,6 +12,9 @@ export = {
   StoreEngine: {
     error: {
       PathValidationError,
+      RecordAlreadyExistsError,
+      RecordNotFoundError,
+      RecordTypeError
     },
     FileEngine,
     IndexedDBEngine,

--- a/src/main/store/TransientStore.ts
+++ b/src/main/store/TransientStore.ts
@@ -73,12 +73,12 @@ export default class TransientStore extends EventEmitter {
       .then((cachedBundle: TransientBundle) => {
         return (cachedBundle !== undefined) ? cachedBundle : this.getFromStore(primaryKey);
       })
-      .catch((error) => {
+      .catch(error => {
         if (error instanceof RecordNotFoundError) {
           return undefined;
         }
         throw error;
-      })
+      });
   }
 
   private getFromCache(primaryKey: string): Promise<TransientBundle> {

--- a/src/main/store/TransientStore.ts
+++ b/src/main/store/TransientStore.ts
@@ -1,8 +1,8 @@
 import ExpiredBundle from './ExpiredBundle';
-import RecordAlreadyExistsError from './RecordAlreadyExistsError';
 import TransientBundle from './TransientBundle';
 import {CRUDEngine} from '../engine';
 import {EventEmitter} from 'events';
+import {RecordAlreadyExistsError} from '../engine/error';
 
 export default class TransientStore extends EventEmitter {
   private bundles: { [index: string]: TransientBundle } = {};

--- a/src/main/store/TransientStore.ts
+++ b/src/main/store/TransientStore.ts
@@ -72,7 +72,13 @@ export default class TransientStore extends EventEmitter {
     return this.getFromCache(primaryKey)
       .then((cachedBundle: TransientBundle) => {
         return (cachedBundle !== undefined) ? cachedBundle : this.getFromStore(primaryKey);
-      });
+      })
+      .catch((error) => {
+        if (error.name === 'RecordNotFoundError') {
+          return undefined;
+        }
+        throw error;
+      })
   }
 
   private getFromCache(primaryKey: string): Promise<TransientBundle> {

--- a/src/main/store/TransientStore.ts
+++ b/src/main/store/TransientStore.ts
@@ -2,7 +2,7 @@ import ExpiredBundle from './ExpiredBundle';
 import TransientBundle from './TransientBundle';
 import {CRUDEngine} from '../engine';
 import {EventEmitter} from 'events';
-import {RecordAlreadyExistsError} from '../engine/error';
+import {RecordAlreadyExistsError, RecordNotFoundError} from '../engine/error';
 
 export default class TransientStore extends EventEmitter {
   private bundles: { [index: string]: TransientBundle } = {};
@@ -74,7 +74,7 @@ export default class TransientStore extends EventEmitter {
         return (cachedBundle !== undefined) ? cachedBundle : this.getFromStore(primaryKey);
       })
       .catch((error) => {
-        if (error.name === 'RecordNotFoundError') {
+        if (error instanceof RecordNotFoundError) {
           return undefined;
         }
         throw error;

--- a/src/main/store/index.ts
+++ b/src/main/store/index.ts
@@ -1,11 +1,9 @@
 import ExpiredBundle from './ExpiredBundle';
-import RecordAlreadyExistsError from './RecordAlreadyExistsError';
 import TransientBundle from './TransientBundle';
 import TransientStore from './TransientStore';
 
 export {
   ExpiredBundle,
-  RecordAlreadyExistsError,
   TransientBundle,
   TransientStore,
 };

--- a/src/test/browser/engine/IndexedDBEngine.test.js
+++ b/src/test/browser/engine/IndexedDBEngine.test.js
@@ -58,6 +58,19 @@ describe('StoreEngine.IndexedDBEngine', () => {
         .catch(done.fail);
     });
 
+    it('doesn\'t save empty values.', (done) => {
+      const PRIMARY_KEY = 'primary-key';
+
+      const entity = undefined;
+
+      engine.create(TABLE_NAME, PRIMARY_KEY, entity)
+        .then(() => done.fail(new Error('Method is supposed to throw an error.')))
+        .catch((error) => {
+          expect(error).toEqual(jasmine.any(StoreEngine.error.RecordTypeError));
+          done();
+        });
+    });
+
     it('throws an error when attempting to overwrite a record.', (done) => {
       const PRIMARY_KEY = 'primary-key';
 

--- a/src/test/browser/engine/IndexedDBEngine.test.js
+++ b/src/test/browser/engine/IndexedDBEngine.test.js
@@ -58,7 +58,7 @@ describe('StoreEngine.IndexedDBEngine', () => {
         .catch(done.fail);
     });
 
-    it('overwrites an existing database record.', (done) => {
+    it('throws an error when attempting to overwrite a record.', (done) => {
       const PRIMARY_KEY = 'primary-key';
 
       const firstEntity = {
@@ -71,9 +71,8 @@ describe('StoreEngine.IndexedDBEngine', () => {
 
       engine.create(TABLE_NAME, PRIMARY_KEY, firstEntity)
         .then(() => engine.create(TABLE_NAME, PRIMARY_KEY, secondEntity))
-        .then((primaryKey) => engine.read(TABLE_NAME, primaryKey))
-        .then((record) => {
-          expect(record.some).toBe(secondEntity.some);
+        .catch((error) => {
+          expect(error).toEqual(jasmine.any(StoreEngine.error.RecordAlreadyExistsError));
           done();
         });
     });
@@ -194,7 +193,7 @@ describe('StoreEngine.IndexedDBEngine', () => {
           });
       });
 
-      it('returns "undefined" if a record cannot be found.', (done) => {
+      it('throws an error if a record cannot be found.', (done) => {
         const PRIMARY_KEY = 'primary-key';
 
         engine.read(TABLE_NAME, PRIMARY_KEY)

--- a/src/test/browser/engine/IndexedDBEngine.test.js
+++ b/src/test/browser/engine/IndexedDBEngine.test.js
@@ -198,11 +198,11 @@ describe('StoreEngine.IndexedDBEngine', () => {
         const PRIMARY_KEY = 'primary-key';
 
         engine.read(TABLE_NAME, PRIMARY_KEY)
-          .then((record) => {
-            expect(record).toBeUndefined();
+          .then(() => done.fail(new Error('Method is supposed to throw an error.')))
+          .catch((error) => {
+            expect(error).toEqual(jasmine.any(StoreEngine.error.RecordNotFoundError));
             done();
-          })
-          .catch((error) => done.fail(error));
+          });
       });
     });
 

--- a/src/test/browser/engine/LocalStorageEngine.test.js
+++ b/src/test/browser/engine/LocalStorageEngine.test.js
@@ -45,7 +45,20 @@ describe('StoreEngine.LocalStorageEngine', () => {
         .catch(done.fail);
     });
 
-    it('overwrites an existing database record.', (done) => {
+    it('doesn\'t save empty values.', (done) => {
+      const PRIMARY_KEY = 'primary-key';
+
+      const entity = undefined;
+
+      engine.create(TABLE_NAME, PRIMARY_KEY, entity)
+        .then(() => done.fail(new Error('Method is supposed to throw an error.')))
+        .catch((error) => {
+          expect(error).toEqual(jasmine.any(StoreEngine.error.RecordTypeError));
+          done();
+        });
+    });
+
+    it('throws an error when attempting to overwrite a record.', (done) => {
       const PRIMARY_KEY = 'primary-key';
 
       const firstEntity = {
@@ -58,9 +71,8 @@ describe('StoreEngine.LocalStorageEngine', () => {
 
       engine.create(TABLE_NAME, PRIMARY_KEY, firstEntity)
         .then(() => engine.create(TABLE_NAME, PRIMARY_KEY, secondEntity))
-        .then((primaryKey) => engine.read(TABLE_NAME, primaryKey))
-        .then((record) => {
-          expect(record.some).toBe(secondEntity.some);
+        .catch((error) => {
+          expect(error).toEqual(jasmine.any(StoreEngine.error.RecordAlreadyExistsError));
           done();
         });
     });

--- a/src/test/browser/engine/LocalStorageEngine.test.js
+++ b/src/test/browser/engine/LocalStorageEngine.test.js
@@ -194,15 +194,15 @@ describe('StoreEngine.LocalStorageEngine', () => {
         });
     });
 
-    it('returns "undefined" if a record cannot be found.', (done) => {
+    it('throws an error if a record cannot be found.', (done) => {
       const PRIMARY_KEY = 'primary-key';
 
       engine.read(TABLE_NAME, PRIMARY_KEY)
-        .then((record) => {
-          expect(record).toBeUndefined();
+        .then(() => done.fail(new Error('Method is supposed to throw an error.')))
+        .catch((error) => {
+          expect(error).toEqual(jasmine.any(StoreEngine.error.RecordNotFoundError));
           done();
-        })
-        .catch((error) => done.fail(error));
+        });
     });
   });
 

--- a/src/test/browser/store/TransientStore.test.js
+++ b/src/test/browser/store/TransientStore.test.js
@@ -84,7 +84,7 @@ describe('store.TransientStore', () => {
     });
 
     it('returns a non-existent record as "undefined".', (done) => {
-      const primaryKey = 'not-found';
+      const primaryKey = 'not-existing';
 
       store.get(primaryKey)
         .then((bundle) => expect(bundle).toBeUndefined())

--- a/src/test/node/spec/engine/FileEngineSpec.js
+++ b/src/test/node/spec/engine/FileEngineSpec.js
@@ -53,6 +53,19 @@ describe('StoreEngine.FileEngine', () => {
         .catch(done.fail);
     });
 
+    it('doesn\'t save empty values.', (done) => {
+      const PRIMARY_KEY = 'primary-key';
+
+      const entity = undefined;
+
+      engine.create(TABLE_NAME, PRIMARY_KEY, entity)
+        .then(() => done.fail(new Error('Method is supposed to throw an error.')))
+        .catch((error) => {
+          expect(error).toEqual(jasmine.any(StoreEngine.error.RecordTypeError));
+          done();
+        });
+    });
+
     it('overwrites an existing database record.', (done) => {
       const PRIMARY_KEY = 'primary-key';
 

--- a/src/test/node/spec/engine/FileEngineSpec.js
+++ b/src/test/node/spec/engine/FileEngineSpec.js
@@ -66,7 +66,7 @@ describe('StoreEngine.FileEngine', () => {
         });
     });
 
-    it('overwrites an existing database record.', (done) => {
+    it('throws an error when attempting to overwrite a record.', (done) => {
       const PRIMARY_KEY = 'primary-key';
 
       const firstEntity = {
@@ -79,9 +79,8 @@ describe('StoreEngine.FileEngine', () => {
 
       engine.create(TABLE_NAME, PRIMARY_KEY, firstEntity)
         .then(() => engine.create(TABLE_NAME, PRIMARY_KEY, secondEntity))
-        .then((primaryKey) => engine.read(TABLE_NAME, primaryKey))
-        .then((record) => {
-          expect(record.some).toBe(secondEntity.some);
+        .catch((error) => {
+          expect(error).toEqual(jasmine.any(StoreEngine.error.RecordAlreadyExistsError));
           done();
         });
     });

--- a/src/test/node/spec/engine/FileEngineSpec.js
+++ b/src/test/node/spec/engine/FileEngineSpec.js
@@ -253,15 +253,15 @@ describe('StoreEngine.FileEngine', () => {
         .catch((error) => done.fail(error)));
     });
 
-    it('returns "undefined" if a record cannot be found.', (done) => {
+    it('throws an error if a record cannot be found.', (done) => {
       const PRIMARY_KEY = 'primary-key';
 
       engine.read(TABLE_NAME, PRIMARY_KEY)
-      .then((record) => {
-        expect(record).toBeUndefined();
-        done();
-      })
-      .catch((error) => done.fail(error));
+        .then(() => done.fail(new Error('Method is supposed to throw an error.')))
+        .catch((error) => {
+          expect(error).toEqual(jasmine.any(StoreEngine.error.RecordNotFoundError));
+          done();
+        });
     });
 
     it('does not allow path traversal', (done) => {

--- a/src/test/node/spec/engine/MemoryEngineSpec.js
+++ b/src/test/node/spec/engine/MemoryEngineSpec.js
@@ -31,7 +31,7 @@ describe('StoreEngine.MemoryEngine', () => {
 
       engine.create(TABLE_NAME, PRIMARY_KEY, entity)
         .then(() => done.fail(new Error('Method is supposed to throw an error.')))
-        .catch((error) => {
+        .catch(error => {
           expect(error).toEqual(jasmine.any(StoreEngine.error.RecordTypeError));
           done();
         });
@@ -179,7 +179,7 @@ describe('StoreEngine.MemoryEngine', () => {
 
       engine.read(TABLE_NAME, PRIMARY_KEY)
         .then(() => done.fail(new Error('Method is supposed to throw an error.')))
-        .catch((error) => {
+        .catch(error => {
           expect(error).toEqual(jasmine.any(StoreEngine.error.RecordNotFoundError));
           done();
         });

--- a/src/test/node/spec/engine/MemoryEngineSpec.js
+++ b/src/test/node/spec/engine/MemoryEngineSpec.js
@@ -24,7 +24,20 @@ describe('StoreEngine.MemoryEngine', () => {
         .catch(done.fail);
     });
 
-    it('overwrites an existing database record.', (done) => {
+    it('doesn\'t save empty values.', (done) => {
+      const PRIMARY_KEY = 'primary-key';
+
+      const entity = undefined;
+
+      engine.create(TABLE_NAME, PRIMARY_KEY, entity)
+        .then(() => done.fail(new Error('Method is supposed to throw an error.')))
+        .catch((error) => {
+          expect(error).toEqual(jasmine.any(StoreEngine.error.RecordTypeError));
+          done();
+        });
+    });
+
+    it('throws an error when attempting to overwrite a record.', (done) => {
       const PRIMARY_KEY = 'primary-key';
 
       const firstEntity = {
@@ -37,9 +50,8 @@ describe('StoreEngine.MemoryEngine', () => {
 
       engine.create(TABLE_NAME, PRIMARY_KEY, firstEntity)
         .then(() => engine.create(TABLE_NAME, PRIMARY_KEY, secondEntity))
-        .then((primaryKey) => engine.read(TABLE_NAME, primaryKey))
-        .then((record) => {
-          expect(record.some).toBe(secondEntity.some);
+        .catch((error) => {
+          expect(error).toEqual(jasmine.any(StoreEngine.error.RecordAlreadyExistsError));
           done();
         });
     });
@@ -162,15 +174,15 @@ describe('StoreEngine.MemoryEngine', () => {
           .catch((error) => done.fail(error)));
     });
 
-    it('returns "undefined" if a record cannot be found.', (done) => {
+    it('throws an error if a record cannot be found.', (done) => {
       const PRIMARY_KEY = 'primary-key';
 
       engine.read(TABLE_NAME, PRIMARY_KEY)
-        .then((record) => {
-          expect(record).toBeUndefined();
+        .then(() => done.fail(new Error('Method is supposed to throw an error.')))
+        .catch((error) => {
+          expect(error).toEqual(jasmine.any(StoreEngine.error.RecordNotFoundError));
           done();
-        })
-        .catch((error) => done.fail(error));
+        });
     });
   });
 

--- a/src/test/node/spec/engine/MemoryEngineSpec.js
+++ b/src/test/node/spec/engine/MemoryEngineSpec.js
@@ -50,7 +50,7 @@ describe('StoreEngine.MemoryEngine', () => {
 
       engine.create(TABLE_NAME, PRIMARY_KEY, firstEntity)
         .then(() => engine.create(TABLE_NAME, PRIMARY_KEY, secondEntity))
-        .catch((error) => {
+        .catch(error => {
           expect(error).toEqual(jasmine.any(StoreEngine.error.RecordAlreadyExistsError));
           done();
         });

--- a/src/test/node/spec/engine/MemoryEngineSpec.js
+++ b/src/test/node/spec/engine/MemoryEngineSpec.js
@@ -171,7 +171,7 @@ describe('StoreEngine.MemoryEngine', () => {
             expect(record.some).toBe(entity.some);
             done();
           })
-          .catch((error) => done.fail(error)));
+          .catch(error => done.fail(error)));
     });
 
     it('throws an error if a record cannot be found.', (done) => {


### PR DESCRIPTION
In order to use the storage engines within [our Cryptobox implementation](https://github.com/wireapp/wire-webapp-cryptobox) they need to become much stricter in terms of saving and updating values. 

Therefore `RecordAlreadyExistsError`, `RecordNotFoundError` & `RecordTypeError` have been introduced. 